### PR TITLE
Add API-based entry code verification

### DIFF
--- a/functions/api/_envcheck.ts
+++ b/functions/api/_envcheck.ts
@@ -1,7 +1,7 @@
 export const onRequestGet: PagesFunction<Env> = async ({ env }) => {
   const mask = (v?: string) => (v ? v.slice(0, 3) + '***' : 'missing')
   const payload = {
-    ENTRY_CODE: mask(env.ENTRY_CODE),
+    ENTRY_CODE: mask(env.ENTRY_CODE || env.VITE_ENTRY_CODE),
     KAKAO_REST_API_KEY: mask(env.KAKAO_REST_API_KEY),
     NCP_API_KEY_ID: mask(env.NCP_API_KEY_ID),
     NCP_API_KEY: mask(env.NCP_API_KEY),
@@ -14,6 +14,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ env }) => {
 
 export interface Env {
   ENTRY_CODE?: string
+  VITE_ENTRY_CODE?: string
   KAKAO_REST_API_KEY?: string
   NCP_API_KEY_ID?: string
   NCP_API_KEY?: string

--- a/functions/api/entry-check.ts
+++ b/functions/api/entry-check.ts
@@ -1,0 +1,43 @@
+export const onRequestPost: PagesFunction<EntryEnv> = async ({ request, env }) => {
+  let code: string | undefined
+
+  try {
+    const body = await request.json<Record<string, unknown>>()
+    if (typeof body.code === 'string') {
+      code = body.code.trim()
+    }
+  } catch (error) {
+    // ignore JSON parse errors and treat as invalid payload
+  }
+
+  if (!code) {
+    return new Response(JSON.stringify({ success: false, error: 'invalid_request' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  const expected = (env.VITE_ENTRY_CODE || env.ENTRY_CODE || '').trim()
+  if (!expected) {
+    return new Response(JSON.stringify({ success: false, error: 'not_configured' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  if (code === expected) {
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  return new Response(JSON.stringify({ success: false, error: 'unauthorized' }), {
+    status: 401,
+    headers: { 'content-type': 'application/json' }
+  })
+}
+
+interface EntryEnv {
+  VITE_ENTRY_CODE?: string
+  ENTRY_CODE?: string
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './App'
 import Enter from './pages/Enter'
 import Home from './pages/Home'
@@ -9,9 +10,7 @@ import Bullet from './pages/Bullet'
 import MapSummary from './pages/MapSummary'
 import Settings from './pages/Settings'
 
-createRoot(document.getElementById('root')!).render(<RouterProvider router={router} />)
-
-export default createBrowserRouter([
+const router = createBrowserRouter([
   { path: '/enter', element: <Enter /> },
   {
     path: '/',
@@ -27,4 +26,6 @@ export default createBrowserRouter([
     ]
   }
 ])
+
+createRoot(document.getElementById('root')!).render(<RouterProvider router={router} />)
 

--- a/src/pages/Enter.tsx
+++ b/src/pages/Enter.tsx
@@ -5,17 +5,58 @@ import { useNavigate } from 'react-router-dom'
 export default function Enter() {
   const [code, setCode] = useState('')
   const [err, setErr] = useState('')
+  const [loading, setLoading] = useState(false)
   const nav = useNavigate()
 
   const submit = async () => {
-    // 서버에 키를 묻지 않고, 실 배포는 CF Pages에서 환경변수로 빌드 혹은 클라이언트에 hardcoding 금지
-    // 여기서는 간단히 _envcheck로 키가 있는지만 보고, 실제 코드는 클라에서 비교하지 않음.
-    const entry = import.meta.env.VITE_ENTRY_CODE || ''
-    if (entry && code === entry) {
+    if (loading) return
+    const typed = code.trim()
+    if (!typed) {
+      setErr('코드를 입력하세요.')
+      return
+    }
+    setErr('')
+    setLoading(true)
+
+    const markEntryAndGoHome = () => {
       setEntryOK(true)
       nav('/')
-    } else {
-      setErr('코드가 올바르지 않습니다.')
+    }
+
+    const fallbackToBuildTimeCode = () => {
+      const entry = (import.meta.env.VITE_ENTRY_CODE || '').trim()
+      if (entry && typed === entry) {
+        markEntryAndGoHome()
+        return true
+      }
+      return false
+    }
+
+    try {
+      const res = await fetch('/api/entry-check', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code: typed })
+      })
+
+      if (res.ok) {
+        markEntryAndGoHome()
+        return
+      }
+
+      if (res.status === 401) {
+        setErr('코드가 올바르지 않습니다.')
+        return
+      }
+
+      if (res.status === 404 && fallbackToBuildTimeCode()) return
+
+      setErr('코드를 확인하는 중 오류가 발생했습니다.')
+    } catch (error) {
+      if (fallbackToBuildTimeCode()) return
+      setErr('코드를 확인하는 중 오류가 발생했습니다.')
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -30,7 +71,13 @@ export default function Enter() {
         placeholder="코드를 입력하세요"
       />
       {err && <div className="text-red-500 text-sm">{err}</div>}
-      <button onClick={submit} className="w-full rounded-lg bg-brand text-white py-3 font-semibold">확인</button>
+      <button
+        onClick={submit}
+        disabled={loading}
+        className="w-full rounded-lg bg-brand text-white py-3 font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {loading ? '확인 중...' : '확인'}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages Function that checks the entry code against runtime environment variables
- update the Enter page to verify the code through the new API with graceful fallbacks and loading states
- allow the _envcheck diagnostic endpoint to pick up VITE_ENTRY_CODE as well as ENTRY_CODE

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcd36ca3908331b64bbdd3f8aada28