### PR TITLE
Switch address search to Juso API and add Naver geocoding

### DIFF
--- a/functions/api/_envcheck.ts
+++ b/functions/api/_envcheck.ts
@@ -1,10 +1,11 @@
 export const onRequestGet: PagesFunction<Env> = async ({ env }) => {
   const mask = (v?: string) => (v ? v.slice(0, 3) + '***' : 'missing')
   const payload = {
-    ENTRY_CODE: mask(env.ENTRY_CODE),
-    KAKAO_REST_API_KEY: mask(env.KAKAO_REST_API_KEY),
-    NCP_API_KEY_ID: mask(env.NCP_API_KEY_ID),
-    NCP_API_KEY: mask(env.NCP_API_KEY),
+    ENTRY_CODE: mask(env.ENTRY_CODE || env.VITE_ENTRY_CODE),
+    KAKAO_REST_KEY: mask(env.KAKAO_REST_KEY || env.KAKAO_REST_API_KEY),
+    JUSO_API_KEY: mask(env.JUSO_API_KEY),
+    NAVER_CLIENT_ID: mask(env.NAVER_CLIENT_ID || env.NCP_API_KEY_ID),
+    NAVER_CLIENT_SECRET: mask(env.NAVER_CLIENT_SECRET || env.NCP_API_KEY),
     ALLOWED_ORIGINS: env.ALLOWED_ORIGINS || '*'
   }
   return new Response(JSON.stringify(payload, null, 2), {
@@ -14,7 +15,12 @@ export const onRequestGet: PagesFunction<Env> = async ({ env }) => {
 
 export interface Env {
   ENTRY_CODE?: string
+  VITE_ENTRY_CODE?: string
+  KAKAO_REST_KEY?: string
   KAKAO_REST_API_KEY?: string
+  JUSO_API_KEY?: string
+  NAVER_CLIENT_ID?: string
+  NAVER_CLIENT_SECRET?: string
   NCP_API_KEY_ID?: string
   NCP_API_KEY?: string
   ALLOWED_ORIGINS?: string

--- a/functions/api/entry-check.ts
+++ b/functions/api/entry-check.ts
@@ -1,0 +1,43 @@
+export const onRequestPost: PagesFunction<EntryEnv> = async ({ request, env }) => {
+  let code: string | undefined
+
+  try {
+    const body = await request.json<Record<string, unknown>>()
+    if (typeof body.code === 'string') {
+      code = body.code.trim()
+    }
+  } catch (error) {
+    // ignore JSON parse errors and treat as invalid payload
+  }
+
+  if (!code) {
+    return new Response(JSON.stringify({ success: false, error: 'invalid_request' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  const expected = (env.VITE_ENTRY_CODE || env.ENTRY_CODE || '').trim()
+  if (!expected) {
+    return new Response(JSON.stringify({ success: false, error: 'not_configured' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  if (code === expected) {
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { 'content-type': 'application/json' }
+    })
+  }
+
+  return new Response(JSON.stringify({ success: false, error: 'unauthorized' }), {
+    status: 401,
+    headers: { 'content-type': 'application/json' }
+  })
+}
+
+interface EntryEnv {
+  VITE_ENTRY_CODE?: string
+  ENTRY_CODE?: string
+}

--- a/functions/api/geocode.ts
+++ b/functions/api/geocode.ts
@@ -1,0 +1,71 @@
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+  const url = new URL(request.url)
+  const roadAddress = (url.searchParams.get('roadAddress') || url.searchParams.get('address') || '').trim()
+
+  if (!roadAddress) {
+    return jsonResponse({ error: 'missing_address' }, env, 400)
+  }
+
+  const clientId = env.NAVER_CLIENT_ID || env.NCP_API_KEY_ID
+  const clientSecret = env.NAVER_CLIENT_SECRET || env.NCP_API_KEY
+
+  if (!clientId || !clientSecret) {
+    return jsonResponse({ error: 'not_configured' }, env, 500)
+  }
+
+  const geocodeUrl = new URL('https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode')
+  geocodeUrl.searchParams.set('query', roadAddress)
+
+  const res = await fetch(geocodeUrl, {
+    headers: {
+      'X-NCP-APIGW-API-KEY-ID': clientId,
+      'X-NCP-APIGW-API-KEY': clientSecret
+    }
+  })
+
+  if (!res.ok) {
+    return jsonResponse({ error: 'naver_fail' }, env, res.status)
+  }
+
+  const data = await res.json()
+  const first = data?.addresses?.[0]
+  if (!first || !first.x || !first.y) {
+    return jsonResponse({ error: 'not_found' }, env, 404)
+  }
+
+  const x = parseFloat(first.x)
+  const y = parseFloat(first.y)
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return jsonResponse({ error: 'invalid_coordinate' }, env, 502)
+  }
+
+  return jsonResponse(
+    {
+      x,
+      y,
+      roadAddress: first.roadAddress || roadAddress,
+      jibunAddress: first.jibunAddress || undefined,
+      zipCode: first.zipcode || first.zipNo || undefined
+    },
+    env
+  )
+}
+
+function jsonResponse(body: any, env: Env, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-origin': env.ALLOWED_ORIGINS || '*'
+    }
+  })
+}
+
+export interface Env {
+  NAVER_CLIENT_ID?: string
+  NAVER_CLIENT_SECRET?: string
+  NCP_API_KEY_ID?: string
+  NCP_API_KEY?: string
+  ALLOWED_ORIGINS?: string
+}

--- a/functions/api/static-map.ts
+++ b/functions/api/static-map.ts
@@ -22,10 +22,17 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   nav.searchParams.append('markers', `type:t|size:mid|pos:${sy} ${sx}|label:S`)
   nav.searchParams.append('markers', `type:t|size:mid|pos:${ey} ${ex}|label:E`)
 
+  const apiId = env.NAVER_CLIENT_ID || env.NCP_API_KEY_ID
+  const apiKey = env.NAVER_CLIENT_SECRET || env.NCP_API_KEY
+
+  if (!apiId || !apiKey) {
+    return new Response('naver api key missing', { status: 500 })
+  }
+
   const res = await fetch(nav.toString(), {
     headers: {
-      'X-NCP-APIGW-API-KEY-ID': env.NCP_API_KEY_ID,
-      'X-NCP-APIGW-API-KEY': env.NCP_API_KEY
+      'X-NCP-APIGW-API-KEY-ID': apiId,
+      'X-NCP-APIGW-API-KEY': apiKey
     }
   })
   return new Response(res.body, {
@@ -39,7 +46,9 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
 }
 
 export interface Env {
-  NCP_API_KEY_ID: string
-  NCP_API_KEY: string
+  NAVER_CLIENT_ID?: string
+  NAVER_CLIENT_SECRET?: string
+  NCP_API_KEY_ID?: string
+  NCP_API_KEY?: string
   ALLOWED_ORIGINS?: string
 }

--- a/src/components/AutoCompleteInput.tsx
+++ b/src/components/AutoCompleteInput.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
 import { SuggestItem } from '@/lib/types'
 
+type AddressCandidate = {
+  title: string
+  subtitle: string
+  roadAddress: string
+  jibunAddress?: string
+  zipCode?: string
+}
+
 export default function AutoCompleteInput({
   label,
   value,
@@ -11,25 +19,119 @@ export default function AutoCompleteInput({
   onSelect: (item: SuggestItem | null) => void
 }) {
   const [q, setQ] = useState('')
-  const [items, setItems] = useState<SuggestItem[]>([])
+  const [items, setItems] = useState<AddressCandidate[]>([])
+  const [pending, setPending] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
   const timer = useRef<number | null>(null)
 
   useEffect(() => {
-    if (q.trim().length < 2) {
+    let cancelled = false
+
+    if (timer.current) {
+      window.clearTimeout(timer.current)
+      timer.current = null
+    }
+
+    const nextQ = q.trim()
+    if (nextQ.length < 2) {
       setItems([])
+      setError(null)
       return
     }
-    if (timer.current) window.clearTimeout(timer.current)
+
+    setError(null)
+
     timer.current = window.setTimeout(async () => {
       try {
-        const res = await fetch(`/api/suggest?q=${encodeURIComponent(q)}`)
-        const data = (await res.json()) as { items: SuggestItem[] }
-        setItems(data.items ?? [])
+        const res = await fetch(`/api/suggest?q=${encodeURIComponent(nextQ)}`)
+        const data = (await res.json()) as { items?: AddressCandidate[]; error?: string }
+        if (!cancelled) {
+          const list = data.items ?? []
+          setItems(list)
+          if (list.length > 0) {
+            setError(null)
+          } else {
+            switch (data.error) {
+              case 'not_configured':
+                setError('주소 검색 API 키가 설정되지 않았습니다.')
+                break
+              case 'juso_fail':
+                setError('주소 검색 서버 응답이 올바르지 않습니다.')
+                break
+              case 'short_query':
+                setError(null)
+                break
+              default:
+                setError('검색 결과가 없습니다.')
+            }
+          }
+        }
       } catch {
-        setItems([])
+        if (!cancelled) {
+          setItems([])
+          setError('주소 목록을 불러오지 못했습니다.')
+        }
+      } finally {
+        timer.current = null
       }
     }, 200)
+
+    return () => {
+      cancelled = true
+      if (timer.current) {
+        window.clearTimeout(timer.current)
+        timer.current = null
+      }
+    }
   }, [q])
+
+  const selectItem = async (candidate: AddressCandidate) => {
+    setPending(candidate.roadAddress)
+    setError(null)
+    try {
+      const res = await fetch(`/api/geocode?roadAddress=${encodeURIComponent(candidate.roadAddress)}`)
+      const data = (await res.json()) as {
+        x?: number
+        y?: number
+        error?: string
+        roadAddress?: string
+        jibunAddress?: string
+        zipCode?: string
+      }
+      if (res.ok && typeof data.x === 'number' && typeof data.y === 'number') {
+        onSelect({
+          title: data.roadAddress || candidate.title,
+          subtitle:
+            candidate.subtitle || data.jibunAddress || data.roadAddress || candidate.title,
+          roadAddress: data.roadAddress || candidate.roadAddress,
+          jibunAddress: data.jibunAddress || candidate.jibunAddress,
+          zipCode: data.zipCode || candidate.zipCode,
+          x: data.x,
+          y: data.y
+        })
+        setQ('')
+        setItems([])
+      } else {
+        let message = '좌표를 찾을 수 없습니다. 다시 시도하세요.'
+        switch (data.error) {
+          case 'not_configured':
+            message = '좌표 검색 API 키가 설정되지 않았습니다.'
+            break
+          case 'naver_fail':
+            message = '좌표 검색 서버 응답이 올바르지 않습니다.'
+            break
+          case 'not_found':
+            message = '선택한 주소의 좌표를 찾지 못했습니다.'
+            break
+        }
+        setError(message)
+      }
+    } catch {
+      setError('좌표를 불러오지 못했습니다. 네트워크 상태를 확인해 주세요.')
+    } finally {
+      setPending(null)
+    }
+  }
 
   return (
     <div>
@@ -38,7 +140,9 @@ export default function AutoCompleteInput({
         <div className="flex items-center gap-2">
           <div className="flex-1 rounded border border-zinc-300 dark:border-zinc-700 px-3 py-2">
             <div className="font-medium">{value.title}</div>
-            <div className="text-xs text-zinc-500">{value.subtitle}</div>
+            <div className="text-xs text-zinc-500">
+              {[value.subtitle, value.zipCode].filter(Boolean).join(' • ')}
+            </div>
           </div>
           <button className="px-2 py-2 rounded border" onClick={() => onSelect(null)}>초기화</button>
         </div>
@@ -52,22 +156,26 @@ export default function AutoCompleteInput({
           />
           {items.length > 0 && (
             <ul className="mt-2 border rounded-lg overflow-hidden border-zinc-200 dark:border-zinc-700">
-              {items.map((it, idx) => (
-                <li
-                  key={idx}
-                  className="px-3 py-2 bg-white dark:bg-zinc-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 cursor-pointer"
-                  onClick={() => {
-                    onSelect(it)
-                    setQ('')
-                    setItems([])
-                  }}
-                >
-                  <div className="font-medium">{it.title}</div>
-                  <div className="text-xs text-zinc-500">{it.subtitle}</div>
-                </li>
-              ))}
+              {items.map((it, idx) => {
+                const isPending = pending === it.roadAddress
+                return (
+                  <li
+                    key={idx}
+                    className={`px-3 py-2 bg-white dark:bg-zinc-900 hover:bg-zinc-50 dark:hover:bg-zinc-800 cursor-pointer ${
+                      isPending ? 'opacity-60 pointer-events-none' : ''
+                    }`}
+                    onClick={() => selectItem(it)}
+                  >
+                    <div className="font-medium">{it.title}</div>
+                    <div className="text-xs text-zinc-500">
+                      {[it.subtitle, it.zipCode].filter(Boolean).join(' • ')}
+                    </div>
+                  </li>
+                )
+              })}
             </ul>
           )}
+          {error && <div className="mt-2 text-xs text-rose-500">{error}</div>}
         </>
       )}
     </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,9 @@
-export type SuggestItem = { title: string; subtitle: string; x: number; y: number }
+export type SuggestItem = {
+  title: string
+  subtitle: string
+  roadAddress: string
+  jibunAddress?: string
+  zipCode?: string
+  x: number
+  y: number
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createRoot } from 'react-dom/client'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './App'
 import Enter from './pages/Enter'
 import Home from './pages/Home'
@@ -9,9 +10,7 @@ import Bullet from './pages/Bullet'
 import MapSummary from './pages/MapSummary'
 import Settings from './pages/Settings'
 
-createRoot(document.getElementById('root')!).render(<RouterProvider router={router} />)
-
-export default createBrowserRouter([
+const router = createBrowserRouter([
   { path: '/enter', element: <Enter /> },
   {
     path: '/',
@@ -27,4 +26,6 @@ export default createBrowserRouter([
     ]
   }
 ])
+
+createRoot(document.getElementById('root')!).render(<RouterProvider router={router} />)
 

--- a/src/pages/Enter.tsx
+++ b/src/pages/Enter.tsx
@@ -5,17 +5,58 @@ import { useNavigate } from 'react-router-dom'
 export default function Enter() {
   const [code, setCode] = useState('')
   const [err, setErr] = useState('')
+  const [loading, setLoading] = useState(false)
   const nav = useNavigate()
 
   const submit = async () => {
-    // 서버에 키를 묻지 않고, 실 배포는 CF Pages에서 환경변수로 빌드 혹은 클라이언트에 hardcoding 금지
-    // 여기서는 간단히 _envcheck로 키가 있는지만 보고, 실제 코드는 클라에서 비교하지 않음.
-    const entry = import.meta.env.VITE_ENTRY_CODE || ''
-    if (entry && code === entry) {
+    if (loading) return
+    const typed = code.trim()
+    if (!typed) {
+      setErr('코드를 입력하세요.')
+      return
+    }
+    setErr('')
+    setLoading(true)
+
+    const markEntryAndGoHome = () => {
       setEntryOK(true)
       nav('/')
-    } else {
-      setErr('코드가 올바르지 않습니다.')
+    }
+
+    const fallbackToBuildTimeCode = () => {
+      const entry = (import.meta.env.VITE_ENTRY_CODE || '').trim()
+      if (entry && typed === entry) {
+        markEntryAndGoHome()
+        return true
+      }
+      return false
+    }
+
+    try {
+      const res = await fetch('/api/entry-check', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code: typed })
+      })
+
+      if (res.ok) {
+        markEntryAndGoHome()
+        return
+      }
+
+      if (res.status === 401) {
+        setErr('코드가 올바르지 않습니다.')
+        return
+      }
+
+      if (res.status === 404 && fallbackToBuildTimeCode()) return
+
+      setErr('코드를 확인하는 중 오류가 발생했습니다.')
+    } catch (error) {
+      if (fallbackToBuildTimeCode()) return
+      setErr('코드를 확인하는 중 오류가 발생했습니다.')
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -30,7 +71,13 @@ export default function Enter() {
         placeholder="코드를 입력하세요"
       />
       {err && <div className="text-red-500 text-sm">{err}</div>}
-      <button onClick={submit} className="w-full rounded-lg bg-brand text-white py-3 font-semibold">확인</button>
+      <button
+        onClick={submit}
+        disabled={loading}
+        className="w-full rounded-lg bg-brand text-white py-3 font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {loading ? '확인 중...' : '확인'}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace the Kakao keyword lookup with the Juso address search API and surface the new secrets in the env check endpoint
- add a geocode Pages Function that resolves coordinates through Naver and have the autocomplete component fetch coordinates when an address is picked
- update the static map proxy and shared types to work with the NAVER_* secrets and richer address metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcd36ca3908331b64bbdd3f8aada28